### PR TITLE
Pin Alpine version to 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 os: linux
+dist: focal
 language: shell
 services: docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG alpine_version=edge
+ARG alpine_version=3.13
 
 FROM alpine:${alpine_version} as base
 RUN apk update && apk upgrade


### PR DESCRIPTION
Alpine `edge` (>3.13) requires very recent versions of `seccomp` (>=2.4.4) and `docker` (>=20.10.0). Thus stick with `3.13` for now.